### PR TITLE
Group API 

### DIFF
--- a/src/main/java/com/srib/personaldatabase/controller/GroupController.java
+++ b/src/main/java/com/srib/personaldatabase/controller/GroupController.java
@@ -1,0 +1,44 @@
+package com.srib.personaldatabase.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.srib.personaldatabase.domain.Group;
+import com.srib.personaldatabase.service.GroupService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Tag(name = "Group API", description = "API for å håndtere grupper og medlemskap")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @Operation(summary = "Hent alle grupper", description = "Returnerer en liste med alle grupper")
+    @GetMapping
+    public List<Group> getGroups() {
+        return groupService.getAllGroups();
+    }
+
+    @Operation(summary = "Lag en ny gruppe", description = "Legger til en ny gruppe")
+    @PostMapping
+    public Group createGroup(@RequestBody Group group) {
+        return groupService.createGroup(group);
+    }
+
+    @Operation(summary = "Legg en person til i en gruppe", description = "Knytter en eksisterende person til en gruppe via ID")
+    @PostMapping("/{groupId}/persons/{personId}")
+    public void addPersonToGroup(@PathVariable Long groupId, @PathVariable Long personId) {
+        groupService.addPersonToGroup(groupId, personId);
+    }
+}

--- a/src/main/java/com/srib/personaldatabase/domain/Group.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Group.java
@@ -1,0 +1,45 @@
+package com.srib.personaldatabase.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.ManyToMany;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "groups")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "group_id")
+public class Group {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
+  private Long group_id;
+
+  private String group_name;
+  private String group_description;
+  private LocalDateTime group_created_date;
+
+  @ManyToMany(mappedBy = "groups")
+  private Set<Person> persons = new HashSet<>();
+
+  public Group(String group_name) {
+    this.group_name = group_name;
+  }
+
+}

--- a/src/main/java/com/srib/personaldatabase/domain/Person.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Person.java
@@ -35,7 +35,7 @@ public class Person {
 
     private String studentCardNumber;
 
-    private String rolee;
+    private String role;
 
     private String lastSignedContract;
 

--- a/src/main/java/com/srib/personaldatabase/domain/Person.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Person.java
@@ -35,7 +35,7 @@ public class Person {
 
     private String studentCardNumber;
 
-    private String role;
+    private String rolee;
 
     private String lastSignedContract;
 

--- a/src/main/java/com/srib/personaldatabase/domain/Person.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Person.java
@@ -1,10 +1,19 @@
 package com.srib.personaldatabase.domain;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Person {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +48,8 @@ public class Person {
     private String role;
 
     private String lastSignedContract;
-
-
+    @ManyToMany
+    @JoinTable(name = "person_group", joinColumns = @JoinColumn(name = "person_id"), inverseJoinColumns = @JoinColumn(name = "group_id"))
+    private Set<Group> groups = new HashSet<>();
 
 }

--- a/src/main/java/com/srib/personaldatabase/repository/GroupRepository.java
+++ b/src/main/java/com/srib/personaldatabase/repository/GroupRepository.java
@@ -1,0 +1,10 @@
+package com.srib.personaldatabase.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.srib.personaldatabase.domain.Group;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/srib/personaldatabase/service/GroupService.java
+++ b/src/main/java/com/srib/personaldatabase/service/GroupService.java
@@ -1,0 +1,35 @@
+package com.srib.personaldatabase.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.srib.personaldatabase.domain.Group;
+import com.srib.personaldatabase.domain.Person;
+import com.srib.personaldatabase.repository.GroupRepository;
+import com.srib.personaldatabase.repository.PersonRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+  private final GroupRepository groupRepository;
+  private final PersonRepository personRepository;
+
+  public List<Group> getAllGroups() {
+    return groupRepository.findAll();
+  }
+
+  public Group createGroup(Group group) {
+    return groupRepository.save(group);
+  }
+
+  public void addPersonToGroup(Long groupId, Long personId) {
+    Person person = personRepository.findById(personId).orElseThrow();
+    Group group = groupRepository.findById(groupId).orElseThrow();
+
+    person.getGroups().add(group);
+    personRepository.save(person);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new "Group" feature to the application, enabling management of groups and their memberships. The changes add full support for creating, listing, and associating groups with persons, including database entities, API endpoints, and service logic.

### Group Feature Implementation

* Added the `Group` entity with fields for name, description, creation date, and a many-to-many relationship with `Person`. This includes JPA annotations and Jackson identity configuration for serialization. (`src/main/java/com/srib/personaldatabase/domain/Group.java`)
* Updated the `Person` entity to establish a bidirectional many-to-many relationship with `Group`, including JPA mapping and Jackson identity configuration. (`src/main/java/com/srib/personaldatabase/domain/Person.java`) [[1]](diffhunk://#diff-3718aae2ac8b8074cef56eee8413621d5d0bfac4139510d4d4a0157350a0f868R3-R16) [[2]](diffhunk://#diff-3718aae2ac8b8074cef56eee8413621d5d0bfac4139510d4d4a0157350a0f868R25) [[3]](diffhunk://#diff-3718aae2ac8b8074cef56eee8413621d5d0bfac4139510d4d4a0157350a0f868L41-R53)

### API and Service Layer

* Implemented `GroupController` to expose REST API endpoints for listing groups, creating groups, and adding persons to groups. Includes Swagger annotations for documentation. (`src/main/java/com/srib/personaldatabase/controller/GroupController.java`)
* Added `GroupService` with business logic for group operations: retrieving all groups, creating a group, and adding a person to a group. (`src/main/java/com/srib/personaldatabase/service/GroupService.java`)

### Persistence

* Introduced `GroupRepository` for database access to groups using Spring Data JPA. (`src/main/java/com/srib/personaldatabase/repository/GroupRepository.java`)