### PR TITLE
Added department class

### DIFF
--- a/src/main/java/com/srib/personaldatabase/controller/DepartmentController.java
+++ b/src/main/java/com/srib/personaldatabase/controller/DepartmentController.java
@@ -1,0 +1,74 @@
+package com.srib.personaldatabase.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.srib.personaldatabase.domain.Department;
+import com.srib.personaldatabase.service.DepartmentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/departments")
+@RequiredArgsConstructor
+@Tag(name = "Department API", description = "API for å håndtere avdelinger og grupper")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    @Operation(summary = "Hent alle avdelinger")
+    @GetMapping
+    public List<Department> getDepartments() {
+        return departmentService.getAllDepartments();
+    }
+
+    @Operation(summary = "Hent en avdeling via ID")
+    @GetMapping("/{id}")
+    public Department getDepartment(@PathVariable Long id) {
+        return departmentService.getDepartment(id);
+    }
+
+    @Operation(summary = "Lag en ny avdeling")
+    @PostMapping
+    public Department createDepartment(@RequestBody Department department) {
+        return departmentService.createDepartment(department);
+    }
+
+    @Operation(summary = "Oppdater en avdeling via ID")
+    @PutMapping("/{id}")
+    public Department updateDepartment(@PathVariable Long id, @RequestBody Department department) {
+        return departmentService.updateDepartment(id, department);
+    }
+
+    @Operation(summary = "Slett en avdeling via ID")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDepartment(@PathVariable Long id) {
+        departmentService.deleteDepartment(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Legg en gruppe til i en avdeling")
+    @PostMapping("/{departmentId}/groups/{groupId}")
+    public ResponseEntity<Void> addGroupToDepartment(@PathVariable Long departmentId, @PathVariable Long groupId) {
+        departmentService.addGroupToDepartment(departmentId, groupId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Fjern en gruppe fra en avdeling")
+    @DeleteMapping("/{departmentId}/groups/{groupId}")
+    public ResponseEntity<Void> removeGroupFromDepartment(@PathVariable Long departmentId, @PathVariable Long groupId) {
+        departmentService.removeGroupFromDepartment(departmentId, groupId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/srib/personaldatabase/domain/Department.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Department.java
@@ -1,0 +1,43 @@
+package com.srib.personaldatabase.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "departments")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Department {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long department_id;
+
+    private String department_name;
+
+    private String department_description;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "department")
+    private Set<Group> groups = new HashSet<>();
+
+    public Department(String department_name) {
+        this.department_name = department_name;
+    }
+}

--- a/src/main/java/com/srib/personaldatabase/domain/Group.java
+++ b/src/main/java/com/srib/personaldatabase/domain/Group.java
@@ -1,9 +1,12 @@
 package com.srib.personaldatabase.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -33,6 +36,10 @@ public class Group {
   private String group_description;
   
   private LocalDateTime group_created_date;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "department_id")
+  private Department department;
 
   @JsonIgnore
   @ManyToMany(mappedBy = "groups")

--- a/src/main/java/com/srib/personaldatabase/repository/DepartmentRepository.java
+++ b/src/main/java/com/srib/personaldatabase/repository/DepartmentRepository.java
@@ -1,0 +1,10 @@
+package com.srib.personaldatabase.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.srib.personaldatabase.domain.Department;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+}

--- a/src/main/java/com/srib/personaldatabase/service/DepartmentService.java
+++ b/src/main/java/com/srib/personaldatabase/service/DepartmentService.java
@@ -1,0 +1,63 @@
+package com.srib.personaldatabase.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.srib.personaldatabase.domain.Department;
+import com.srib.personaldatabase.domain.Group;
+import com.srib.personaldatabase.repository.DepartmentRepository;
+import com.srib.personaldatabase.repository.GroupRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+    private final GroupRepository groupRepository;
+
+    public List<Department> getAllDepartments() {
+        return departmentRepository.findAll();
+    }
+
+    public Department getDepartment(Long id) {
+        return departmentRepository.findById(id).orElseThrow();
+    }
+
+    public Department createDepartment(Department department) {
+        return departmentRepository.save(department);
+    }
+
+    public Department updateDepartment(Long id, Department updated) {
+        Department existing = departmentRepository.findById(id).orElseThrow();
+        existing.setDepartment_name(updated.getDepartment_name());
+        existing.setDepartment_description(updated.getDepartment_description());
+        return departmentRepository.save(existing);
+    }
+
+    public void deleteDepartment(Long id) {
+        Department department = departmentRepository.findById(id).orElseThrow();
+        for (Group group : department.getGroups()) {
+            group.setDepartment(null);
+            groupRepository.save(group);
+        }
+        departmentRepository.delete(department);
+    }
+
+    public void addGroupToDepartment(Long departmentId, Long groupId) {
+        Department department = departmentRepository.findById(departmentId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        group.setDepartment(department);
+        groupRepository.save(group);
+    }
+
+    public void removeGroupFromDepartment(Long departmentId, Long groupId) {
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        if (group.getDepartment() != null && group.getDepartment().getDepartment_id().equals(departmentId)) {
+            group.setDepartment(null);
+            groupRepository.save(group);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces full CRUD support and group management for departments in the application. It adds a complete `Department` domain model, controller, service, and repository, and establishes a bidirectional relationship between `Department` and `Group`. The main changes are grouped as follows:

### Department Entity and Persistence

* Added the `Department` entity (`Department.java`), including fields for name, description, and a set of associated `Group` entities, with appropriate JPA annotations for persistence.
* Created the `DepartmentRepository` interface to enable database operations for departments.

### Department API Layer

* Implemented the `DepartmentController` with endpoints to create, read, update, delete, and manage groups within departments, following RESTful conventions and annotated for OpenAPI documentation.

### Department Service Layer

* Added the `DepartmentService` class to handle business logic for all department operations, including CRUD and adding/removing groups from departments.

### Group Entity Relationship

* Updated the `Group` entity to include a `ManyToOne` relationship to `Department`, establishing the link from groups to their parent department. [[1]](diffhunk://#diff-7a8ea2f4f36a02d254039ce3d1734e18ad3148480e9b19932edf057f5f8d9f83R4-R9) [[2]](diffhunk://#diff-7a8ea2f4f36a02d254039ce3d1734e18ad3148480e9b19932edf057f5f8d9f83R40-R43)

These changes together provide a robust foundation for managing departments and their associated groups within the application.